### PR TITLE
Update version to 6.1 for next development cycle

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates and others.
+    Copyright (c) 1997, 2024 Oracle and/or its affiliates and others.
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -30,7 +30,7 @@
 
     <groupId>jakarta.el</groupId>
     <artifactId>jakarta.el-api</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Jakarta Expression Language API</name>
@@ -93,7 +93,7 @@
 
     <properties>
         <!-- Make sure the two versions are in sync with the maven version -->
-        <spec.version>6.0</spec.version>
+        <spec.version>6.1</spec.version>
         <bundle.version>${project.version}</bundle.version>
         <extensionName>jakarta.el</extensionName>
         <bundle.symbolicName>jakarta.el-api</bundle.symbolicName>

--- a/api/src/main/java/jakarta/el/package.html
+++ b/api/src/main/java/jakarta/el/package.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1997, 2022 Oracle and/or its affiliates and others.
+    Copyright (c) 1997, 2024 Oracle and/or its affiliates and others.
     All rights reserved.
     Copyright 2004 The Apache Software Foundation
 
@@ -24,7 +24,7 @@
 </head>
 
 <body bgcolor="white">
-Provides the API for <strong>Jakarta Expression Language 6.0</strong>
+Provides the API for <strong>Jakarta Expression Language 6.1</strong>
 
 <p>Jakarta Expression Language is a simple language originally designed to
 satisfy the specific needs of web application developers. It has evolved
@@ -223,7 +223,7 @@ of a Jakarta Expression Language variable to the Jakarta Expression Language exp
 </p>
 
 <h3><a name="Standalone">Jakarta Expression Language in Stand-alone environment</a></h3>
-<p>Jakarta Expression Language 6.0 includes APIs for using Jakarta Expression Language in a stand-alone environment.</p>
+<p>Jakarta Expression Language 6.1 includes APIs for using Jakarta Expression Language in a stand-alone environment.</p>
 <p>{@link jakarta.el.ELProcessor} provides simple APIs for the direct
 evaluations of expressions. It also makes it easy to define functions,
 set variables, and define beans locally.</p>

--- a/api/src/main/javadoc/doc-files/EFSL.html
+++ b/api/src/main/javadoc/doc-files/EFSL.html
@@ -41,10 +41,10 @@
 
 <p>The notice is:</p>
 
-<p>&quot;Copyright &copy; 2018, 2022 Eclipse Foundation. This software or
+<p>&quot;Copyright &copy; 2018, 2024 Eclipse Foundation. This software or
   document includes material copied from or derived from
   Jakarta ® Expression Language
-  https://jakarta.ee/specifications/expression-language/6.0/&quot;</p>
+  https://jakarta.ee/specifications/expression-language/6.1/&quot;</p>
 
 <h2>Disclaimers</h2>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation.
+    Copyright (c) 2020, 2024 Contributors to the Eclipse Foundation.
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -29,7 +29,7 @@
 
     <groupId>jakarta.el</groupId>
     <artifactId>el-parent</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Expression Language</name>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.el</groupId>
     <artifactId>expression-language-spec</artifactId>
-    <version>6.0-SNAPSHOT</version>
+    <version>6.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Expression Language Specification</name>

--- a/spec/src/main/asciidoc/ELSpec.adoc
+++ b/spec/src/main/asciidoc/ELSpec.adoc
@@ -1,6 +1,6 @@
 :xrefstyle: full
 :sectnums!:
-== Jakarta Expression Language, Version 6.0
+== Jakarta Expression Language, Version 6.1
 
 Copyright (c) 2013, 2024 Oracle and/or its affiliates and others.
 All rights reserved.
@@ -17,7 +17,7 @@ Comments to: el-dev@eclipse.org
 == Preface
 
 This is the Expression Language specification
-version 6.0, developed by the Jakarta Expression Language Team under the Eclipse
+version 6.1, developed by the Jakarta Expression Language Team under the Eclipse
 Foundation Specification Process.
 
 === Historical Note
@@ -2997,6 +2997,9 @@ empty.
 
 This appendix lists the changes in the EL specification.
 This appendix is non-normative.
+
+=== Changes between 6.1 and 6.0
+
 
 === Changes between 6.0 and 5.0
 

--- a/spec/src/main/asciidoc/license-efsl.adoc
+++ b/spec/src/main/asciidoc/license-efsl.adoc
@@ -55,7 +55,7 @@ The notice is:
 "Copyright © 2018, 2024 Eclipse Foundation. This software or document
 includes material copied from or derived from
 Jakarta ® Expression Language
-https://jakarta.ee/specifications/expression-language/6.0/[https://jakarta.ee/specifications/expression-language/6.0/]"
+https://jakarta.ee/specifications/expression-language/6.1/[https://jakarta.ee/specifications/expression-language/6.1/]"
 
 ==== Disclaimers
 


### PR DESCRIPTION
Using 6.1 for the next version as there isn't anything I am currently aware of that would require a major version change for the next release.