### PR TITLE
Fix NPE when targetType is null

### DIFF
--- a/impl/src/main/java/com/sun/el/parser/AstValue.java
+++ b/impl/src/main/java/com/sun/el/parser/AstValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -217,7 +217,7 @@ public final class AstValue extends SimpleNode {
             if (ctx.isPropertyResolved()) {
                 value = targetValue;
             } else {
-                if (value != null || targetType.isPrimitive()) {
+                if (value != null || (targetType != null && targetType.isPrimitive())) {
                     value = ELSupport.coerceToType(value, targetType);
                 }
             }


### PR DESCRIPTION
There are some cases when targetType could be null, and it throws NPE:


```
Caused by: javax.el.ELException: java.lang.NullPointerException: Cannot invoke "java.lang.Class.isPrimitive()" because "targetType" is null
        at javax.el.BeanELResolver.getValue(BeanELResolver.java:304)
        at com.sun.faces.el.DemuxCompositeELResolver._getValue(DemuxCompositeELResolver.java:173)
        at com.sun.faces.el.DemuxCompositeELResolver.getValue(DemuxCompositeELResolver.java:200)
        at com.sun.el.parser.AstValue.getValue(AstValue.java:114)
        at com.sun.el.parser.AstValue.getValue(AstValue.java:177)
        at com.sun.el.ValueExpressionImpl.getValue(ValueExpressionImpl.java:183)
        at com.sun.faces.application.ApplicationImpl.createComponent(ApplicationImpl.java:271)
        ... 338 more
Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.Class.isPrimitive()" because "targetType" is null
        at com.sun.el.parser.AstValue.setValue(AstValue.java:220)
        at com.sun.el.ValueExpressionImpl.setValue(ValueExpressionImpl.java:248)
```

This is a backport of:
https://github.com/jakartaee/expression-language/pull/140