### PR TITLE
Fix #313. Add inner class support to ImportHandler

### DIFF
--- a/api/src/test/java/jakarta/el/TestImportHandler.java
+++ b/api/src/test/java/jakarta/el/TestImportHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package jakarta.el;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestImportHandler {
+
+    /*
+     * https://github.com/jakartaee/expression-language/issues/313
+     */
+    @Test
+    public void testResolveInnerClass() throws Exception {
+        ImportHandler importHandler = new ImportHandler();
+
+        importHandler.importClass("jakarta.el.TesterUtil.Numbers");
+        Class<?> clazz = importHandler.resolveClass("Numbers");
+
+        Assertions.assertEquals(TesterUtil.Numbers.class, clazz);
+    }
+}

--- a/api/src/test/java/jakarta/el/TesterUtil.java
+++ b/api/src/test/java/jakarta/el/TesterUtil.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package jakarta.el;
+
+public class TesterUtil {
+
+    public enum Numbers {
+        ONE,
+        TWO,
+        THREE
+    }
+}

--- a/spec/src/main/asciidoc/ELSpec.adoc
+++ b/spec/src/main/asciidoc/ELSpec.adoc
@@ -2,7 +2,7 @@
 :sectnums!:
 == Jakarta Expression Language, Version 6.1
 
-Copyright (c) 2013, 2024 Oracle and/or its affiliates and others.
+Copyright (c) 2013, 2025 Oracle and/or its affiliates and others.
 All rights reserved.
 
 Eclipse is a registered trademark of the Eclipse Foundation. Jakarta
@@ -3000,6 +3000,10 @@ This appendix is non-normative.
 
 === Changes between 6.1 and 6.0
 
+* https://github.com/jakartaee/expression-language/issues/313[#313]
+  Add support for inner classes when using the `ImportHandler` and clarify that
+  the import handler expects canonical class names where full class names are
+  required.
 
 === Changes between 6.0 and 5.0
 


### PR DESCRIPTION
Also clarifies that ImportHandler expects the canonical class name where a full class name is required.