### PR TITLE
Add support for Date coercion

### DIFF
--- a/spec/src/main/asciidoc/ELSpec.adoc
+++ b/spec/src/main/asciidoc/ELSpec.adoc
@@ -1616,16 +1616,40 @@ Note: If coercion of any element in the array fails, the coercion of the array f
 
 ==== Coerce `A` to functional interface method invocation
 
- * If `A` is a `LambdaExpression` then:
+* If `A` is a `LambdaExpression` then:
  
- ** Return the result of invoking the `LambdaExpression` with the parameters
-    (coerced if necessary) that were passed to the Functional Interface method
-    invocation
+** Return the result of invoking the `LambdaExpression` with the parameters
+   (coerced if necessary) that were passed to the Functional Interface method
+   invocation
  
- * Otherwise, apply the rules in <<Coerce `A` to Any Other Type `T`>>
+* Otherwise, apply the rules in <<Coerce `A` to Any Other Type `T`>>
 
 Note: A Type is only considered to be a functional interface it it is annotated
 with `java.lang.FunctionalInterface`.
+
+==== Coerce `A` to `java.time.Instant`
+
+* If `A` is `null`, return `null`
+
+* If `A` is `java.time.Instant`, return `A`
+
+* If `A` is `java.time.temporal.TemporalAccessor`, return `Instant.from(A)`
+
+* If `A` is `java.time.Clock`, return `A.instant()`
+
+* If `A` is `java.util.Date`, return `A.toInstant()`
+
+* If `A` is `String`, return `Instant.parse(A)`
+
+* Otherwise, error
+
+==== Coerce `A` to `java.util.Date`
+
+* If `A` is `null`, return `null`
+
+* If `A` is `java.util.Date`, return `A`
+
+* Coerce `A` to `Instant` and then call `java.util.Date.from(A)`
 
 ==== Coerce `A` to Any Other Type `T`
 

--- a/spec/src/main/asciidoc/ELSpec.adoc
+++ b/spec/src/main/asciidoc/ELSpec.adoc
@@ -944,6 +944,10 @@ and use the return value of `A.compareTo(B)`
 * If `A` or `B` is `Byte`, `Short`, `Character`, `Integer`, or `Long`
 coerce both `A` and `B` to `Long` and apply operator
 
+* If `A` or `B` is `java.time.temporal.TemporalAccessor`, `java.time.Clock` or
+`java.util.Date` coerce both `A` and `B` to `java.time.Instant` and use the
+return value of `A.compareTo(B)`.
+ 
 * If `A` or `B` is `String` coerce both `A` and `B` to `String`, compare
 lexically
 
@@ -973,7 +977,7 @@ for `!=` or `ne`
 
 ** If operator is `==` or `eq`, return `A.equals(B)`
 
-** If operator is `!=` or `ne`, retur `!A.equals(B)`
+** If operator is `!=` or `ne`, return `!A.equals(B)`
 
 * If `A` or `B` is `Float` or `Double` coerce both `A` and `B` to
 `Double`, apply operator
@@ -993,6 +997,13 @@ apply operator
 
 * If `A` or `B` is an enum, coerce both `A` and `B` to enum, apply
 operator
+
+* If `A` or `B` is `java.time.temporal.TemporalAccessor`, `java.time.Clock` or
+`java.util.Date` coerce both `A` and `B` to `java.time.Instant`  and then:
+
+** If operator is `==` or `eq`, return `A.equals(B)`
+
+** If operator is `!=` or `ne`, return `!A.equals(B)`
 
 * If `A` or `B` is `String` coerce both `A` and `B` to `String`, compare
 lexically
@@ -3129,6 +3140,10 @@ This appendix is non-normative.
 * https://github.com/jakartaee/expression-language/issues/247[#247]
   Expand the definition of the concatenation operator (`+=`) to include
   collections.
+
+* https://github.com/jakartaee/expression-language/issues/273[#273]
+  Expand the types that can be used with the relational operators to include
+  types that represent a date and time.
 
 * https://github.com/jakartaee/expression-language/issues/278[#278]
   Restore definition of `Identifier` as `Java Language Identifier` and clarify

--- a/tck/src/main/java/com/sun/ts/tests/el/common/util/TestNum.java
+++ b/tck/src/main/java/com/sun/ts/tests/el/common/util/TestNum.java
@@ -26,11 +26,7 @@ import java.util.ArrayList;
  */
 public final class TestNum {
 
-    private static final String COMPARATOR = "1";
-
-    private static ArrayList<Float> floatList;
-
-    private static ArrayList<Object> numberList;
+    private static final String NUMBER_REFERENCE = "1";
 
     /**
      * Private as this class will only have static methods and members.
@@ -45,7 +41,7 @@ public final class TestNum {
      */
     public static ArrayList<Float> getFloatList() {
 
-        floatList = new ArrayList<>();
+        ArrayList<Float> floatList = new ArrayList<>();
 
         floatList.add(Float.valueOf("1.00005f"));
         floatList.add(Float.valueOf("1.5E-4d"));
@@ -64,19 +60,19 @@ public final class TestNum {
      */
     public static ArrayList<Object> getNumberList() {
 
-        numberList = new ArrayList<>();
+        ArrayList<Object> numberList = new ArrayList<>();
 
-        numberList.add(BigDecimal.valueOf(Long.parseLong(COMPARATOR)));
-        numberList.add(Double.valueOf(COMPARATOR));
-        numberList.add(Float.valueOf(COMPARATOR));
-        numberList.add(COMPARATOR + ".0");
-        numberList.add(COMPARATOR + "e0");
-        numberList.add(COMPARATOR + "E0");
-        numberList.add(BigInteger.valueOf(Long.parseLong(COMPARATOR)));
-        numberList.add(Long.valueOf(COMPARATOR));
-        numberList.add(Integer.valueOf(COMPARATOR));
-        numberList.add(Short.valueOf(COMPARATOR));
-        numberList.add(Byte.valueOf(COMPARATOR));
+        numberList.add(BigDecimal.valueOf(Long.parseLong(NUMBER_REFERENCE)));
+        numberList.add(Double.valueOf(NUMBER_REFERENCE));
+        numberList.add(Float.valueOf(NUMBER_REFERENCE));
+        numberList.add(NUMBER_REFERENCE + ".0");
+        numberList.add(NUMBER_REFERENCE + "e0");
+        numberList.add(NUMBER_REFERENCE + "E0");
+        numberList.add(BigInteger.valueOf(Long.parseLong(NUMBER_REFERENCE)));
+        numberList.add(Long.valueOf(NUMBER_REFERENCE));
+        numberList.add(Integer.valueOf(NUMBER_REFERENCE));
+        numberList.add(Short.valueOf(NUMBER_REFERENCE));
+        numberList.add(Byte.valueOf(NUMBER_REFERENCE));
 
         return numberList;
 

--- a/tck/src/main/java/com/sun/ts/tests/el/common/util/TestNum.java
+++ b/tck/src/main/java/com/sun/ts/tests/el/common/util/TestNum.java
@@ -14,10 +14,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
-/*
- * $Id$
- */
 package com.sun.ts.tests.el.common.util;
 
 import java.math.BigDecimal;
@@ -25,64 +21,64 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 
 /**
- * Used to store lists that will be utilized accross the board for a common
+ * Used to store lists that will be utilized across the board for a common
  * point of reference when testing.
  */
 public final class TestNum {
 
-  private static final String COMPARATOR = "1";
+    private static final String COMPARATOR = "1";
 
-  private static ArrayList<Float> floatList;
+    private static ArrayList<Float> floatList;
 
-  private static ArrayList<Object> numberList;
+    private static ArrayList<Object> numberList;
 
-  /**
-   * Private as this class will only have static methods and members.
-   */
-  private TestNum() {
-  }
+    /**
+     * Private as this class will only have static methods and members.
+     */
+    private TestNum() {
+    }
 
-  /**
-   * Used for a common list of Float values when testing.
-   *
-   * @return - A set list of common Floats that we use as test values.
-   */
-  public static ArrayList<Float> getFloatList() {
+    /**
+     * Used for a common list of Float values when testing.
+     *
+     * @return - A set list of common Floats that we use as test values.
+     */
+    public static ArrayList<Float> getFloatList() {
 
-    floatList = new ArrayList<>();
+        floatList = new ArrayList<>();
 
-    floatList.add(Float.valueOf("1.00005f"));
-    floatList.add(Float.valueOf("1.5E-4d"));
-    floatList.add(Float.valueOf("1.5E+4"));
-    floatList.add(Float.valueOf("1.5e+4"));
+        floatList.add(Float.valueOf("1.00005f"));
+        floatList.add(Float.valueOf("1.5E-4d"));
+        floatList.add(Float.valueOf("1.5E+4"));
+        floatList.add(Float.valueOf("1.5e+4"));
 
-    return floatList;
+        return floatList;
 
-  }
+    }
 
-  /**
-   * Used a common reference point for Number types and a common value is
-   * assigned (1).
-   *
-   * @return - A common List of Number types with a constant value.
-   */
-  public static ArrayList<Object> getNumberList() {
+    /**
+     * Used a common reference point for Number types and a common value is
+     * assigned (1).
+     *
+     * @return - A common List of Number types with a constant value.
+     */
+    public static ArrayList<Object> getNumberList() {
 
-    numberList = new ArrayList<>();
+        numberList = new ArrayList<>();
 
-    numberList.add(BigDecimal.valueOf(Long.parseLong(COMPARATOR)));
-    numberList.add(Double.valueOf(COMPARATOR));
-    numberList.add(Float.valueOf(COMPARATOR));
-    numberList.add(COMPARATOR + ".0");
-    numberList.add(COMPARATOR + "e0");
-    numberList.add(COMPARATOR + "E0");
-    numberList.add(BigInteger.valueOf(Long.parseLong(COMPARATOR)));
-    numberList.add(Long.valueOf(COMPARATOR));
-    numberList.add(Integer.valueOf(COMPARATOR));
-    numberList.add(Short.valueOf(COMPARATOR));
-    numberList.add(Byte.valueOf(COMPARATOR));
+        numberList.add(BigDecimal.valueOf(Long.parseLong(COMPARATOR)));
+        numberList.add(Double.valueOf(COMPARATOR));
+        numberList.add(Float.valueOf(COMPARATOR));
+        numberList.add(COMPARATOR + ".0");
+        numberList.add(COMPARATOR + "e0");
+        numberList.add(COMPARATOR + "E0");
+        numberList.add(BigInteger.valueOf(Long.parseLong(COMPARATOR)));
+        numberList.add(Long.valueOf(COMPARATOR));
+        numberList.add(Integer.valueOf(COMPARATOR));
+        numberList.add(Short.valueOf(COMPARATOR));
+        numberList.add(Byte.valueOf(COMPARATOR));
 
-    return numberList;
+        return numberList;
 
-  }
+    }
 }

--- a/tck/src/main/java/com/sun/ts/tests/el/common/util/TestNum.java
+++ b/tck/src/main/java/com/sun/ts/tests/el/common/util/TestNum.java
@@ -18,7 +18,12 @@ package com.sun.ts.tests.el.common.util;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 
 /**
  * Used to store lists that will be utilized across the board for a common
@@ -27,6 +32,10 @@ import java.util.ArrayList;
 public final class TestNum {
 
     private static final String NUMBER_REFERENCE = "1";
+
+    public static final Instant DATE_REFERENCE_BEFORE = Instant.parse("2025-04-03T02:00:59.00Z");
+    public static final Instant DATE_REFERENCE = Instant.parse("2025-04-03T02:01:00.00Z");
+    public static final Instant DATE_REFERENCE_AFTER = Instant.parse("2025-04-03T02:01:01.00Z");
 
     /**
      * Private as this class will only have static methods and members.
@@ -76,5 +85,22 @@ public final class TestNum {
 
         return numberList;
 
+    }
+
+
+    /**
+     * Used to provide a list of date and times using different implementations
+     * that all refer to 2025-04-03 02:01 UTC.
+     */
+    public static ArrayList<Object> getDateTimeList() {
+
+        ArrayList<Object> dateTimeList = new ArrayList<>();
+
+        dateTimeList.add(Date.from(DATE_REFERENCE));
+        dateTimeList.add(Clock.fixed(DATE_REFERENCE, ZoneId.of("Z")));
+        dateTimeList.add(DATE_REFERENCE);
+        dateTimeList.add(ZonedDateTime.ofInstant(DATE_REFERENCE, ZoneId.of("+12:00")));
+
+        return dateTimeList;
     }
 }

--- a/tck/src/main/java/com/sun/ts/tests/el/spec/coercion/DateTimeCoercionIT.java
+++ b/tck/src/main/java/com/sun/ts/tests/el/spec/coercion/DateTimeCoercionIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.ts.tests.el.spec.coercion;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.sun.ts.tests.el.common.util.ExprEval;
+import com.sun.ts.tests.el.common.util.NameValuePair;
+import com.sun.ts.tests.el.common.util.TestNum;
+
+public class DateTimeCoercionIT {
+
+    private static final Map<Object,Instant> mapInputExpectedResult;
+
+    static {
+        Map<Object,Instant> map = new LinkedHashMap<>();
+
+        map.put(null, null);
+        for (Object obj : TestNum.getDateTimeList()) {
+            map.put(obj, TestNum.DATE_REFERENCE);
+        }
+
+        mapInputExpectedResult = Collections.unmodifiableMap(map);
+    }
+
+
+    @Test
+    public void testCoercetoInstant() {
+        for (Map.Entry<Object,Instant> entry : mapInputExpectedResult.entrySet()) {
+            NameValuePair values[] = NameValuePair.buildUnaryNameValue(entry.getKey());
+            Object result = ExprEval.evaluateValueExpression("${A}", values, Instant.class);
+            if (entry.getValue() == null) {
+                Assertions.assertNull(result);
+            } else {
+                Assertions.assertTrue(ExprEval.compareClass(result, Instant.class));
+                Assertions.assertEquals(result, entry.getValue());
+            }
+        }
+    }
+
+
+    @Test
+    public void testCoercetoDate() {
+        for (Map.Entry<Object,Instant> entry : mapInputExpectedResult.entrySet()) {
+            NameValuePair values[] = NameValuePair.buildUnaryNameValue(entry.getKey());
+            Object result = ExprEval.evaluateValueExpression("${A}", values, Date.class);
+            if (entry.getValue() == null) {
+                Assertions.assertNull(result);
+            } else {
+                Assertions.assertTrue(ExprEval.compareClass(result, Date.class));
+                Assertions.assertEquals(result, entry.getValue() == null ? null : Date.from(entry.getValue()));
+            }
+        }
+    }
+}

--- a/tck/src/main/java/com/sun/ts/tests/el/spec/relationaloperator/DateTimeOperandsIT.java
+++ b/tck/src/main/java/com/sun/ts/tests/el/spec/relationaloperator/DateTimeOperandsIT.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.ts.tests.el.spec.relationaloperator;
+
+import java.lang.System.Logger;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.sun.ts.tests.el.common.util.ExprEval;
+import com.sun.ts.tests.el.common.util.NameValuePair;
+import com.sun.ts.tests.el.common.util.TestNum;
+
+public class DateTimeOperandsIT {
+
+    private static final Logger logger = System.getLogger(DateTimeOperandsIT.class.getName());
+
+    private List<Object> dateTimeList = Collections.unmodifiableList(TestNum.getDateTimeList());
+
+
+    @Test
+    public void elDateTest() throws Exception {
+        doTypeTest(x -> Date.from(x));
+    }
+
+    @Test
+    public void elClockTest() throws Exception {
+        doTypeTest(x -> Clock.fixed(x, ZoneId.of("Z")));
+    }
+
+    @Test
+    public void elInstantTest() throws Exception {
+        doTypeTest(x -> x);
+    }
+
+    @Test
+    public void elTemporalTest() throws Exception {
+        doTypeTest(x -> ZonedDateTime.ofInstant(x, ZoneId.of("+12:00")));
+    }
+
+    @Test
+    public void elStringTest() throws Exception {
+        doTypeTest(x -> x.toString());
+    }
+
+    private void doTypeTest(InstantToObject converter) {
+        doEqualToTest(converter);
+        doNotEqualToTest(converter);
+        doLessThanTest(converter);
+        doLessThanOrEqualTest(converter);
+        doGreaterThanOrEqualTest(converter);
+        doGreaterThanTest(converter);
+    }
+
+
+    private void doEqualToTest(InstantToObject converter) {
+        doTest(converter, List.of("==", "eq"), Boolean.FALSE, Boolean.TRUE, Boolean.FALSE);
+    }
+
+
+    private void doNotEqualToTest(InstantToObject converter) {
+        doTest(converter, List.of("!=", "ne"), Boolean.TRUE, Boolean.FALSE, Boolean.TRUE);
+    }
+
+
+    private void doLessThanTest(InstantToObject converter) {
+        doTest(converter, List.of("<", "lt"), Boolean.TRUE, Boolean.FALSE, Boolean.FALSE);
+    }
+
+
+    private void doLessThanOrEqualTest(InstantToObject converter) {
+        doTest(converter, List.of("<=", "le"), Boolean.TRUE, Boolean.TRUE, Boolean.FALSE);
+    }
+
+
+    private void doGreaterThanOrEqualTest(InstantToObject converter) {
+        doTest(converter, List.of(">=", "ge"), Boolean.FALSE, Boolean.TRUE, Boolean.TRUE);
+    }
+
+
+    private void doGreaterThanTest(InstantToObject converter) {
+        doTest(converter, List.of(">", "gt"), Boolean.FALSE, Boolean.FALSE, Boolean.TRUE);
+    }
+
+    private void doTest(InstantToObject converter, List<String> operators, Boolean beforeResult, Boolean equalResult,
+            Boolean afterResult) {
+        for (String operator : operators) {
+            // Value passed in is before the reference date.
+            testOperatorRelational(converter.toObject(TestNum.DATE_REFERENCE_BEFORE), beforeResult, operator);
+
+            // Value passed in is equal to the reference date.
+            testOperatorRelational(converter.toObject(TestNum.DATE_REFERENCE), equalResult, operator);
+
+            // Value passed in is after the reference date.
+            testOperatorRelational(converter.toObject(TestNum.DATE_REFERENCE_AFTER), afterResult, operator);
+        }
+    }
+
+
+    private void testOperatorRelational(Object testValue, Boolean expectedResult, String operator) {
+
+        for (Object testDateTime : dateTimeList) {
+            NameValuePair values[] = NameValuePair.buildNameValuePair(testValue, testDateTime);
+
+            try {
+                String expr = ExprEval.buildElExpr(false, operator);
+                logger.log(Logger.Level.TRACE, "expression to be evaluated is " + expr);
+                logger.log(Logger.Level.TRACE, "types are " + testValue.getClass().getName() + " and " +
+                        testDateTime.getClass().getName());
+
+                Object result = ExprEval.evaluateValueExpression(expr, values, Object.class);
+
+                Assertions.assertTrue(ExprEval.compareClass(result, Boolean.class));
+                Assertions.assertEquals(result, expectedResult);
+            } finally {
+                ExprEval.cleanup();
+            }
+        }
+    }
+
+
+    @FunctionalInterface
+    public interface InstantToObject {
+        Object toObject(Instant instant);
+    }
+}


### PR DESCRIPTION
Fixes #273 

Adds general coercion support to `Instant` and `Date`.

For relational operators supports `TemporalAccessor`, `Clock`, `Date`.

I'll leave this open for a couple of weeks for comment before merging.