### PR TITLE
Pom updates

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -234,7 +234,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.5.0</version>
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -249,7 +248,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.4.0</version>
                 <configuration>
                     <includePom>true</includePom>
                 </configuration>
@@ -267,7 +265,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.12.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -148,8 +148,6 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <!-- Override parent until parent is updated -->
-                <version>3.2.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.jruby</groupId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -27,8 +27,8 @@
         <relativePath/>
     </parent>
 
-    <groupId>jakarta.tck</groupId>
-    <artifactId>jakarta-expression-language-tck</artifactId>
+    <groupId>jakarta.el</groupId>
+    <artifactId>expression-language-tck</artifactId>
     <version>6.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 


### PR DESCRIPTION
Primarily moves El TCK to the jakarta.el group ID but also removes some now unnecessary version overrides.